### PR TITLE
fix(ci): fix CI following schema changes with latest ggscout release

### DIFF
--- a/charts/ggscout/examples/conjurcloud/values.yaml
+++ b/charts/ggscout/examples/conjurcloud/values.yaml
@@ -6,14 +6,15 @@ inventory:
     sources:
       conjur_cloud:
         type: conjurcloud
-        auth_mode: "cyberark"
-        client_id: "${CYBERARK_CLIENT_ID}"
-        client_secret: "${CYBERARK_CLIENT_SECRET}"
+        auth:
+          auth_mode: "cyber_ark"
+          client_id: "${CYBERARK_CLIENT_ID}"
+          client_secret: "${CYBERARK_CLIENT_SECRET}"
+          tenant_id: "${CYBERARK_TENANT_ID}"
         conjur_url: "${CONJUR_URL}"
         fetch_all_versions: true
         mode: "read/write" # Can be `read`, `write` or `read/write` depending on wether fetch and/or sync are enabled
         subdomain: "${CONJUR_SUBDOMAIN}"
-        tenant_id: "${CYBERARK_TENANT_ID}"
 
     gitguardian:
       endpoint: "https://my-gg-instance/v1"
@@ -24,14 +25,14 @@ inventory:
       # Set to `false` to disable the job
       enabled: true
       # Run every 15 minutes
-      schedule: '*/15 * * * *'
+      schedule: "*/15 * * * *"
       send: true
     # Job to be able to sync/write secrets from GitGuardian into you vault
     sync:
       # Set to `false` to disable the job
       enabled: true
       # Run every minute
-      schedule: '* * * * *'
+      schedule: "* * * * *"
 
 envFrom:
 - secretRef:

--- a/charts/ggscout/examples/gcpsecretmanager/values.yaml
+++ b/charts/ggscout/examples/gcpsecretmanager/values.yaml
@@ -7,7 +7,9 @@ inventory:
       gcp:
         type: gcpsecretmanager
         fetch_all_versions: true # Fetch all versions of secrets or not
-        service_account_key_file: /gcp-key-secret/gcp_key.json # Path to GCP key file mounted from Secret
+        auth:
+          auth_mode: "service_account_key_file"
+          key_file: /gcp-key-secret/gcp_key.json # Path to GCP key file mounted from Secret
         # projects: # List of GCP project ids or null
         #   - project-id-1
         #   - project-id-2


### PR DESCRIPTION
Following ggscout 0.18.0 release, we need to modify existing values.yaml files for GCP and Conjur to validate the schemas